### PR TITLE
'shell' checking pip existance doesn't changed status.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Check if PIP needs to be installed
   shell: "command -v pip &&echo '1'||echo '0'"
   register: pip_exists
+  changed_when: false
 
 - include: install.yml
   when: pip_exists.stdout=="0"


### PR DESCRIPTION
"Check if PIP needs to be installed" task always returns changed=true. But this changed status isn't needed. Thus, this PR makes this changed status false every time.
